### PR TITLE
default behaviour of checkboxes is now as follows:

### DIFF
--- a/src/components/filterblog.js
+++ b/src/components/filterblog.js
@@ -19,7 +19,7 @@ export default class FilterBlog extends Component {
       let categoryObject = {
         id: i,
         value: category,
-        isChecked: true,
+        isChecked: false,
       }
       categoriesArray.push(categoryObject)
     })

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -9,10 +9,27 @@ export default class blog extends Component {
     super()
     this.state = {
       selectedCategories: [],
-      foo: [],
     }
     this.updateSelectedCategories = this.updateSelectedCategories.bind(this)
     this.handleSeeMore = this.handleSeeMore.bind(this)
+  }
+
+  componentDidMount() {
+    const posts = this.props.data.allContentfulBlogPost.edges
+    let categories = []
+    posts.forEach(post => {
+      categories.push(post.node.category)
+    })
+    const uniqueCategories = new Set(categories)
+    console.log(uniqueCategories)
+    let selectedCategories = []
+    uniqueCategories.forEach(category => {
+      let categoryObject = { name: category, postLimit: 6 }
+      selectedCategories.push(categoryObject)
+    })
+    this.setState({
+      selectedCategories,
+    })
   }
 
   handleSeeMore(e, i) {
@@ -36,13 +53,14 @@ export default class blog extends Component {
     selected.forEach(category => {
       if (category.isChecked) {
         // create an object with key value pair of name: name, postLimit: 6
-        let categoryObect = { name: category.value, postLimit: 6 }
+        let categoryObect = { name: category.value }
         selectedCategories.push(categoryObect)
       }
       this.setState({
         selectedCategories,
       })
     })
+    console.log(this.state.selectedCategories.length)
   }
 
   render() {
@@ -61,6 +79,7 @@ export default class blog extends Component {
     // only pass down the posts that belong to the category
     let displayedSections = categoryArray.map((category, i) => {
       const { postLimit } = this.state.selectedCategories[i]
+
       return (
         <BlogSection
           posts={posts}


### PR DESCRIPTION
- all checkboxes unchecked, all categories appear on page on load (postLimit 6)
- default selectedCategory state: an array of all the categories, postLimit is 6
- clicking a checkbox resets the selectedCategory with only the ones that have been clicked, no postLimit

this is done by using a componentDidMount that by default populates all categories

when a checkbox is changed, the handleCheckChildElement function is triggers, and it overwrites the state with whatever is checked.